### PR TITLE
Add check $results array indexes exist

### DIFF
--- a/src/JeroenDesloovere/Geolocation/Geolocation.php
+++ b/src/JeroenDesloovere/Geolocation/Geolocation.php
@@ -135,8 +135,8 @@ class Geolocation
 
         // return coordinates latitude/longitude
         return array(
-            'latitude' => (float) $results[0]->geometry->location->lat,
-            'longitude' => (float) $results[0]->geometry->location->lng
+            'latitude' => array_key_exists(0, $results) ? (float) $results[0]->geometry->location->lat : null,
+            'longitude' => array_key_exists(0, $results) ? (float) $results[0]->geometry->location->lng : null
         );
     }
 }


### PR DESCRIPTION
Add array_key_exists before accessing $results index otherwise php launches a fatal error on an unexisting array index access. Reproduce: simply pass "test" string as street only.

Thanks
