### PR TITLE
Add support for HTTPS and Google Maps API keys

### DIFF
--- a/src/Geolocation.php
+++ b/src/Geolocation.php
@@ -12,11 +12,19 @@ namespace JeroenDesloovere\Geolocation;
 class Geolocation
 {
     // API URL
-    const API_URL = 'http://maps.googleapis.com/maps/api/geocode/json';
+    const API_URL = 'maps.googleapis.com/maps/api/geocode/json';
 
-    public function __construct($api_key = null)
+    private $api_key;
+    private $https;
+
+    public function __construct($api_key = null, $https = false)
     {
-        $this->api_key = $api_key;
+        $this->https = $https;
+
+        if ($api_key) {
+            $this->api_key = $api_key;
+            $this->https = true;
+        }
     }
 
     /**
@@ -34,7 +42,7 @@ class Geolocation
         }
 
         // define url
-        $url = self::API_URL . '?';
+        $url = ($this->https ? 'https://' : 'http://') . self::API_URL . '?';
 
         // add every parameter to the url
         foreach ($parameters as $key => $value) $url .= $key . '=' . urlencode($value) . '&';

--- a/src/Geolocation.php
+++ b/src/Geolocation.php
@@ -14,6 +14,11 @@ class Geolocation
     // API URL
     const API_URL = 'http://maps.googleapis.com/maps/api/geocode/json';
 
+    public function __construct($api_key = null)
+    {
+        $this->api_key = $api_key;
+    }
+
     /**
      * Do call
      *
@@ -36,6 +41,10 @@ class Geolocation
 
         // trim last &
         $url = trim($url, '&');
+
+        if ($this->api_key) {
+            $url .= '&key=' . $this->api_key;
+        }
 
         // init curl
         $curl = curl_init();


### PR DESCRIPTION
Helpful if you want to allow users to include an API key, as you can get pretty heavily rate limited without one. HTTPS is required if an API key is provided.