### PR TITLE
Fixes #9

### DIFF
--- a/src/Geolocation.php
+++ b/src/Geolocation.php
@@ -80,7 +80,9 @@ class Geolocation
         $response = json_decode($response);
 
         // API returns with an error
-        if (isset($response->error_message)) throw new GeolocationException($response->error_message);
+        if (isset($response->error_message)) {
+            throw new GeolocationException($response->error_message);
+        }
 
         // return the content
         return $response->results;

--- a/src/Geolocation.php
+++ b/src/Geolocation.php
@@ -79,6 +79,9 @@ class Geolocation
         // redefine response as json decoded
         $response = json_decode($response);
 
+        // API returns with an error
+        if (isset($response->error_message)) throw new GeolocationException($response->error_message);
+
         // return the content
         return $response->results;
     }


### PR DESCRIPTION
Throws an exception with the `error_message` returned by the API as message instead of returning an empty lat/long